### PR TITLE
Restore spies before spying just in case

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ often you want to test how components are rendered with different prop values. t
 to create a tester, run create and pass in the component under test to "be used"
 
     const tester = ReactTester.create().use(Address);
-    
+
 then add a flavour which takes a name and a props object
 
     const NO_ADDRESS = tester.addFlavour('NO_ADDRESS', {
       addressee: 'Mr Robert Smith',
     });
-    
+
 then the flavour can be tested on, here the NONE flavour's type is checked
 
     const actual = NONE.type;
@@ -73,7 +73,7 @@ here we find all AddressLine components for the NO_ADDRESS flavour, take the fir
     const addressee = NO_ADDRESS.findComponents(AddressLine)[0];
     const actual = addressee.props.text;
     const expected = 'Mr Robert Smith';
- 
+
     assert.deepEqual(actual, expected);
 
 ### .getState() => state{object}
@@ -88,7 +88,7 @@ here we fire the click function given to the dumb component and confirm that the
     const expected = stampTypes.FIRST_CLASS;
 
     assert.deepEqual(actual, expected);
-    
+
 ### .propFunc(propName{string}), .mapsTo(methodName{string}) => isMapped{boolean}
 
 propFunc takes a string which is the prop of a dumb component to which you are passing a function
@@ -97,19 +97,27 @@ mapTo takes a string which maps to the method on the smart component class
 
 the returned value will be a boolean indicating if the given prop function maps to the expected class method
 
-here we test that the stamp dumb component was correctly given the smart component's handleOnClick method 
+here we test that the stamp dumb component was correctly given the smart component's handleOnClick method
 
     const isMapped =
           NONE
             .component
             .propFunc('onClick')
             .mapsTo('handleOnClick');
-    
+
     assert(isMapped);
 
 ### .resetState()
 
 returns the state of the flavour of the component under test to the initial state
+
+### .teardown()
+
+If for any reason you need to restore spies placed on a component as part of set up you can use the teardown method. Returns the tester.
+
+    const tester = ReactTester.create().use(Address);
+    // Do stuff...
+    tester.teardown();
 
 ## properties
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ here we test that the stamp dumb component was correctly given the smart compone
 
 returns the state of the flavour of the component under test to the initial state
 
-### .teardown()
+### .teardown() => {ReactComponentTester}
 
 If for any reason you need to restore spies placed on a component as part of set up you can use the teardown method. Returns the tester.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-component-tester",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "A simple helper to make testing react components with shallow rendering easier",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -157,10 +157,17 @@ const testerInit = function() {
 };
 
 // METHODS
+const restoreSpy = function(method) {
+  if (method.isSinonProxy) {
+    method.restore();
+  }
+};
+
 const use = function(Component) {
   const ignore = ['constructor', 'componentWillUnmount', 'render'];
   Object.getOwnPropertyNames(Component.prototype).forEach(method => {
     if (!~ignore.indexOf(method)) {
+      restoreSpy(Component.prototype[method]);
       sinon.spy(Component.prototype, method);
     }
   });
@@ -196,9 +203,20 @@ const addFlavour = function(name, props) {
   );
 };
 
+const teardown = function() {
+  const proto = this.ComponentToUse.prototype;
+
+  Object.getOwnPropertyNames(proto).forEach(method => {
+    restoreSpy(proto[method]);
+  });
+
+  return this;
+};
+
 const testerMethods = {
   use,
   addFlavour,
+  teardown,
 };
 
 // STAMP

--- a/tests/stand-alone/spies-teardown/spies-teardown-tests.js
+++ b/tests/stand-alone/spies-teardown/spies-teardown-tests.js
@@ -3,50 +3,47 @@ import SpiesTeardown from './spies-teardown';
 import ReactTester from '../../../src/index';
 
 describe('spies teardown', () => {
-  let component;
+  let tester;
 
   beforeEach(() => {
-    component = ReactTester
+    tester = ReactTester
       .create()
       .use(SpiesTeardown);
   });
 
-  describe('refreshes spies each time', () => {
-    beforeEach(() => {
-      component
-        .addFlavour('lemon', {});
+  describe('refresh spies each time should', () => {
+    beforeEach(() => tester.addFlavour('LEMON', {}));
+
+    it('allow normal spy behaviour on the first test pass', () => {
+      const actual = tester.ComponentToUse.prototype.spiedOn.callCount;
+      const expected = 1;
+
+      assert(actual, expected);
     });
 
-    it('is called once the first time I check', () => {
-      const callcount = component.ComponentToUse.prototype.spiedOn.callCount;
+    it('allow normal spy behaviour on the second test pass', () => {
+      const actual = tester.ComponentToUse.prototype.spiedOn.callCount;
+      const expected = 1;
 
-      assert(callcount, 1);
-    });
-
-    it('is called once the second time I check', () => {
-      const callcount = component.ComponentToUse.prototype.spiedOn.callCount;
-
-      assert(callcount, 1);
+      assert(actual, expected);
     });
   });
 
-  describe('allows me to tear down when I want to', () => {
-    beforeEach(() => {
-      component
-        .addFlavour('chocolate', {});
+  describe('should', () => {
+    beforeEach(() => tester.addFlavour('CHOCOLATE', {}));
+
+    it('add spies automatically', () => {
+      const actual = tester.ComponentToUse.prototype.spiedOn.isSinonProxy;
+      const expected = true;
+      assert(actual, expected);
     });
 
-    it('spies automatically', () => {
-      const isSpy = component.ComponentToUse.prototype.spiedOn.isSinonProxy;
+    it('allow them to be unwrapped', () => {
+      tester.teardown();
+      const actual = typeof tester.ComponentToUse.prototype.spiedOn.isSinonProxy;
+      const expected = 'undefined';
 
-      assert(isSpy, true);
-    });
-
-    it('can be unwrapped', () => {
-      component.teardown();
-      const isSpy = typeof component.ComponentToUse.prototype.spiedOn.isSinonProxy;
-
-      assert(isSpy, 'undefined');
+      assert(actual, expected);
     });
   });
 });

--- a/tests/stand-alone/spies-teardown/spies-teardown-tests.js
+++ b/tests/stand-alone/spies-teardown/spies-teardown-tests.js
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import SpiesTeardown from './spies-teardown';
+import ReactTester from '../../../src/index';
+
+describe('spies teardown', () => {
+  let component;
+
+  beforeEach(() => {
+    component = ReactTester
+      .create()
+      .use(SpiesTeardown);
+  });
+
+  describe('refreshes spies each time', () => {
+    beforeEach(() => {
+      component
+        .addFlavour('lemon', {});
+    });
+
+    it('is called once the first time I check', () => {
+      const callcount = component.ComponentToUse.prototype.spiedOn.callCount;
+
+      assert(callcount, 1);
+    });
+
+    it('is called once the second time I check', () => {
+      const callcount = component.ComponentToUse.prototype.spiedOn.callCount;
+
+      assert(callcount, 1);
+    });
+  });
+
+  describe('allows me to tear down when I want to', () => {
+    beforeEach(() => {
+      component
+        .addFlavour('chocolate', {});
+    });
+
+    it('spies automatically', () => {
+      const isSpy = component.ComponentToUse.prototype.spiedOn.isSinonProxy;
+
+      assert(isSpy, true);
+    });
+
+    it('can be unwrapped', () => {
+      component.teardown();
+      const isSpy = typeof component.ComponentToUse.prototype.spiedOn.isSinonProxy;
+
+      assert(isSpy, 'undefined');
+    });
+  });
+});

--- a/tests/stand-alone/spies-teardown/spies-teardown.js
+++ b/tests/stand-alone/spies-teardown/spies-teardown.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+
+export default class spiesTeardown extends Component {
+
+  spiedOn() {
+    return 'foo';
+  }
+
+  render() {
+    return (
+      <div>
+        { this.spiedOn() }
+      </div>
+    );
+  }
+
+}

--- a/tests/stand-alone/spies-teardown/spies-teardown.js
+++ b/tests/stand-alone/spies-teardown/spies-teardown.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-export default class spiesTeardown extends Component {
+export default class SpiesTeardown extends Component {
 
   spiedOn() {
     return 'foo';


### PR DESCRIPTION
Add .teardown() method to tester so you can do that as you will.
Readme update and version bump.

Sorry no trailing whitespace plugin did it's thing on save.